### PR TITLE
Refactoring: migrate routes to separate modules

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,26 +1,17 @@
 use axum::{
     http::{self, Method},
-    routing::{get, post, put},
     Extension, Router,
 };
-use handlers::{
-    auth_handlers::{
-        login_handler, new_password_handler, otp_handler, send_pass_reset_handler, signup_handler,
-    },
-    cp_handler::code_handler,
-    crud_handlers::{
-        add_friend_handler, change_flag_handler, create_matched_handler, get_accepted_boys_handler,
-        get_all_users_handler, get_boys_handler, get_girl_request_handler, get_girls_handler,
-        get_matched_handler, get_user_by_id_handler, get_user_handler, reject_handler,
-        update_contest_score_handler, update_score_handler, update_user_character_handler,
-    },
-};
+
+use routes::*;
 use sea_orm::Database;
 use tower_http::cors::{AllowOrigin, CorsLayer};
+
 mod bcrypts;
 mod configs;
 mod handlers;
 mod model;
+mod routes;
 mod utils;
 
 #[tokio::main]
@@ -58,28 +49,45 @@ async fn main() {
         .await
         .expect("could not connect");
     let app: Router<()> = Router::new()
-        .route("/sendpassreset", get(send_pass_reset_handler))
-        .route("/newpassword", get(new_password_handler))
-        .route("/otp", get(otp_handler))
-        .route("/login", post(login_handler))
-        .route("/signup", post(signup_handler))
-        .route("/getuser", post(get_user_handler))
-        .route("/getboys", get(get_boys_handler))
-        .route("/getgirls", get(get_girls_handler))
-        .route("/updatescore", put(update_score_handler))
-        .route("/getallusers", get(get_all_users_handler))
-        .route("/addfriend", post(add_friend_handler))
-        .route("/updatecharacter", put(update_user_character_handler))
-        .route("/getgirlrequests", post(get_girl_request_handler))
-        .route("/getacceptedboys", post(get_accepted_boys_handler))
-        .route("/changeflag", post(change_flag_handler))
-        .route("/creatematch", post(create_matched_handler))
-        .route("/getmatched", post(get_matched_handler))
-        .route("/updatecontestscore", put(update_contest_score_handler))
-        .route("/getuserbyid", post(get_user_by_id_handler))
-        .route("/reject", post(reject_handler))
+        .nest("/auth", auth_routes())
+        .nest("/user", user_routes())
         .layer(cors)
         .layer(Extension(db));
+
+    // let app: Router<()> = Router::new()
+
+    //     // auth
+    //     .route("/login", post(login_handler))
+    //     .route("/signup", post(signup_handler))
+    //     .route("/sendpassreset", get(send_pass_reset_handler))
+    //     .route("/newpassword", get(new_password_handler))
+    //     .route("/otp", get(otp_handler))
+    //
+    //     // user
+    //     .route("/getuser", post(get_user_handler))
+    //     .route("/getallusers", get(get_all_users_handler))
+    //     .route("/updatecharacter", put(update_user_character_handler))
+    //     .route("/getuserbyid", post(get_user_by_id_handler))
+    //
+    //     // friends
+    //     .route("/getboys", get(get_boys_handler))
+    //     .route("/getacceptedboys", post(get_accepted_boys_handler))
+    //     .route("/getgirls", get(get_girls_handler))
+    //     .route("/getgirlrequests", post(get_girl_request_handler))
+    //     .route("/addfriend", post(add_friend_handler))
+    //     .route("/changeflag", post(change_flag_handler))
+    //
+    //     // score
+    //     .route("/updatescore", put(update_score_handler))
+    //     .route("/updatecontestscore", put(update_contest_score_handler))
+    //
+    //     // match
+    //     .route("/creatematch", post(create_matched_handler))
+    //     .route("/getmatched", post(get_matched_handler))
+    //     .route("/reject", post(reject_handler))
+    //
+    //     .layer(cors)
+    //     .layer(Extension(db));
 
     let listener = tokio::net::TcpListener::bind("0.0.0.0:3001").await.unwrap();
     println!("Listening");

--- a/src/routes/auth.rs
+++ b/src/routes/auth.rs
@@ -1,0 +1,74 @@
+use axum::{
+    http::{HeaderMap, StatusCode},
+    response::IntoResponse,
+    routing::post,
+    Extension, Json, Router,
+};
+use cookie::Cookie;
+use entity::user;
+use jsonwebtoken::{encode, EncodingKey, Header};
+use sea_orm::{ColumnTrait, DatabaseConnection, EntityTrait, QueryFilter};
+
+use crate::{
+    bcrypts::verify_password,
+    model::{Claims, LoginInfo},
+    utils::constants::JWT_SECRET,
+};
+
+pub fn auth_routes() -> Router {
+    Router::new().route("/login", post(login_handler))
+}
+
+async fn login_handler(
+    Extension(db): Extension<DatabaseConnection>,
+    Json(login_info): Json<LoginInfo>,
+) -> impl IntoResponse {
+    println!("Login Handler");
+    let email = &login_info.email;
+    let password = &login_info.password;
+
+    let user = user::Entity::find()
+        .filter(user::Column::Email.eq(email))
+        .one(&db)
+        .await
+        .unwrap();
+
+    let is_valid;
+    if let Some(ref user) = user {
+        is_valid = verify_password(password, &user.password)
+    } else {
+        return Err(StatusCode::NOT_FOUND);
+    }
+
+    println!("{}", is_valid);
+
+    Ok(if is_valid {
+        let claims = Claims {
+            sub: email.to_string(),
+            exp: (chrono::Utc::now() + chrono::Duration::days(1)).timestamp() as usize,
+        };
+
+        let token = match encode(
+            &Header::default(),
+            &claims,
+            &EncodingKey::from_secret(JWT_SECRET.as_ref()),
+        ) {
+            Ok(tok) => tok,
+            Err(e) => {
+                eprintln!("Error generating token {} !!!", e);
+                return Err(StatusCode::INTERNAL_SERVER_ERROR);
+            }
+        };
+
+        let mut cookie = Cookie::new("token", token);
+        cookie.set_http_only(true);
+
+        let mut headers = HeaderMap::new();
+        headers.insert("Set-Cookie", cookie.to_string().parse().unwrap());
+        return Ok((headers, Json(user)).into_response());
+
+        // Ok(Json(LoginResponse{token}));
+    } else {
+        StatusCode::UNAUTHORIZED.into_response()
+    })
+}

--- a/src/routes/mod.rs
+++ b/src/routes/mod.rs
@@ -1,0 +1,5 @@
+mod auth;
+mod user;
+
+pub use auth::*;
+pub use user::*;

--- a/src/routes/user.rs
+++ b/src/routes/user.rs
@@ -1,0 +1,19 @@
+use axum::{http::StatusCode, response::IntoResponse, routing::get, Extension, Json, Router};
+use entity::user;
+use sea_orm::{DatabaseConnection, EntityTrait};
+
+pub fn user_routes() -> Router {
+    Router::new().route("/getallusers", get(get_all_users_handler))
+}
+
+async fn get_all_users_handler(Extension(db): Extension<DatabaseConnection>) -> impl IntoResponse {
+    let users = user::Entity::find().all(&db).await;
+
+    match users {
+        Ok(users) => Json(users).into_response(),
+        Err(e) => {
+            eprintln!("Failed to get users from the database: {}", e);
+            StatusCode::INTERNAL_SERVER_ERROR.into_response()
+        }
+    }
+}


### PR DESCRIPTION
## Problem
As the number of routes in main.rs grows, it's essential to keep the file organized.

## Solution
Split routes into separate modules

## Notes
More details - [issue](https://github.com/Sidharth-Singh10/Affinity-backend/issues/1)

## Workflow
- [ ] Initial commit
- [ ] Agree on route groups and solution
- [ ] Finish migration for the rest of the routes