### PR TITLE
Refactoring: migrate routes to separate modules

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,49 +47,14 @@ pub async fn run() -> Router<()> {
     let db = Database::connect(db_string)
         .await
         .expect("could not connect");
-
     let app: Router<()> = Router::new()
         .nest("/auth", auth_routes())
         .nest("/user", user_routes())
+        .nest("/matchmaking", matchmaking_routes())
+        .nest("/score", score_routes())
+        .nest("/diagnostics", diagnostics_routes())
         .layer(cors)
         .layer(Extension(db));
-
-    // let app: Router<()> = Router::new()
-    //     // Checks
-    //     .route("/health_check", get(health_check))
-
-    //     // auth
-    //     .route("/login", post(login_handler))
-    //     .route("/signup", post(signup_handler))
-    //     .route("/sendpassreset", get(send_pass_reset_handler))
-    //     .route("/newpassword", get(new_password_handler))
-    //     .route("/otp", get(otp_handler))
-    //
-    //     // user
-    //     .route("/getuser", post(get_user_handler))
-    //     .route("/getallusers", get(get_all_users_handler))
-    //     .route("/updatecharacter", put(update_user_character_handler))
-    //     .route("/getuserbyid", post(get_user_by_id_handler))
-    //
-    //     // friends
-    //     .route("/getboys", get(get_boys_handler))
-    //     .route("/getacceptedboys", post(get_accepted_boys_handler))
-    //     .route("/getgirls", get(get_girls_handler))
-    //     .route("/getgirlrequests", post(get_girl_request_handler))
-    //     .route("/addfriend", post(add_friend_handler))
-    //     .route("/changeflag", post(change_flag_handler))
-    //
-    //     // score
-    //     .route("/updatescore", put(update_score_handler))
-    //     .route("/updatecontestscore", put(update_contest_score_handler))
-    //
-    //     // match
-    //     .route("/creatematch", post(create_matched_handler))
-    //     .route("/getmatched", post(get_matched_handler))
-    //     .route("/reject", post(reject_handler))
-    //
-    //     .layer(cors)
-    //     .layer(Extension(db));
 
     println!("Listening");
     app

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,27 +1,17 @@
 use axum::{
     http::{self, Method},
-    routing::{get, post, put},
     Extension, Router,
 };
-use handlers::{
-    auth_handlers::{
-        login_handler, new_password_handler, otp_handler, send_pass_reset_handler, signup_handler,
-    },
-    cp_handler::code_handler,
-    crud_handlers::{
-        add_friend_handler, change_flag_handler, create_matched_handler, get_accepted_boys_handler,
-        get_all_users_handler, get_boys_handler, get_girl_request_handler, get_girls_handler,
-        get_matched_handler, get_user_by_id_handler, get_user_handler, reject_handler,
-        update_contest_score_handler, update_score_handler, update_user_character_handler,
-    },
-    tests_handlers::health_check,
-};
+
+use routes::*;
 use sea_orm::Database;
 use tower_http::cors::{AllowOrigin, CorsLayer};
+
 mod bcrypts;
 mod configs;
 mod handlers;
 mod model;
+mod routes;
 mod utils;
 
 pub async fn run() -> Router<()> {
@@ -57,30 +47,49 @@ pub async fn run() -> Router<()> {
     let db = Database::connect(db_string)
         .await
         .expect("could not connect");
+
     let app: Router<()> = Router::new()
-        .route("/health_check", get(health_check))
-        .route("/sendpassreset", get(send_pass_reset_handler))
-        .route("/newpassword", get(new_password_handler))
-        .route("/otp", get(otp_handler))
-        .route("/login", post(login_handler))
-        .route("/signup", post(signup_handler))
-        .route("/getuser", post(get_user_handler))
-        .route("/getboys", get(get_boys_handler))
-        .route("/getgirls", get(get_girls_handler))
-        .route("/updatescore", put(update_score_handler))
-        .route("/getallusers", get(get_all_users_handler))
-        .route("/addfriend", post(add_friend_handler))
-        .route("/updatecharacter", put(update_user_character_handler))
-        .route("/getgirlrequests", post(get_girl_request_handler))
-        .route("/getacceptedboys", post(get_accepted_boys_handler))
-        .route("/changeflag", post(change_flag_handler))
-        .route("/creatematch", post(create_matched_handler))
-        .route("/getmatched", post(get_matched_handler))
-        .route("/updatecontestscore", put(update_contest_score_handler))
-        .route("/getuserbyid", post(get_user_by_id_handler))
-        .route("/reject", post(reject_handler))
+        .nest("/auth", auth_routes())
+        .nest("/user", user_routes())
         .layer(cors)
         .layer(Extension(db));
+
+    // let app: Router<()> = Router::new()
+    //     // Checks
+    //     .route("/health_check", get(health_check))
+
+    //     // auth
+    //     .route("/login", post(login_handler))
+    //     .route("/signup", post(signup_handler))
+    //     .route("/sendpassreset", get(send_pass_reset_handler))
+    //     .route("/newpassword", get(new_password_handler))
+    //     .route("/otp", get(otp_handler))
+    //
+    //     // user
+    //     .route("/getuser", post(get_user_handler))
+    //     .route("/getallusers", get(get_all_users_handler))
+    //     .route("/updatecharacter", put(update_user_character_handler))
+    //     .route("/getuserbyid", post(get_user_by_id_handler))
+    //
+    //     // friends
+    //     .route("/getboys", get(get_boys_handler))
+    //     .route("/getacceptedboys", post(get_accepted_boys_handler))
+    //     .route("/getgirls", get(get_girls_handler))
+    //     .route("/getgirlrequests", post(get_girl_request_handler))
+    //     .route("/addfriend", post(add_friend_handler))
+    //     .route("/changeflag", post(change_flag_handler))
+    //
+    //     // score
+    //     .route("/updatescore", put(update_score_handler))
+    //     .route("/updatecontestscore", put(update_contest_score_handler))
+    //
+    //     // match
+    //     .route("/creatematch", post(create_matched_handler))
+    //     .route("/getmatched", post(get_matched_handler))
+    //     .route("/reject", post(reject_handler))
+    //
+    //     .layer(cors)
+    //     .layer(Extension(db));
 
     println!("Listening");
     app

--- a/src/routes/auth.rs
+++ b/src/routes/auth.rs
@@ -1,0 +1,7 @@
+use axum::{routing::post, Router};
+
+use crate::handlers::auth_handlers::login_handler;
+
+pub fn auth_routes() -> Router {
+    Router::new().route("/login", post(login_handler))
+}

--- a/src/routes/auth.rs
+++ b/src/routes/auth.rs
@@ -1,7 +1,17 @@
-use axum::{routing::post, Router};
+use axum::{
+    routing::{get, post},
+    Router,
+};
 
-use crate::handlers::auth_handlers::login_handler;
+use crate::handlers::auth_handlers::{
+    login_handler, new_password_handler, otp_handler, send_pass_reset_handler, signup_handler,
+};
 
 pub fn auth_routes() -> Router {
-    Router::new().route("/login", post(login_handler))
+    Router::new()
+        .route("/login", post(login_handler))
+        .route("/signup", post(signup_handler))
+        .route("/sendpassreset", get(send_pass_reset_handler))
+        .route("/newpassword", get(new_password_handler))
+        .route("/otp", get(otp_handler))
 }

--- a/src/routes/diagnostics.rs
+++ b/src/routes/diagnostics.rs
@@ -1,0 +1,7 @@
+use axum::{routing::get, Router};
+
+use crate::handlers::tests_handlers::health_check;
+
+pub fn diagnostics_routes() -> Router {
+    Router::new().route("/health_check", get(health_check))
+}

--- a/src/routes/matchmaking.rs
+++ b/src/routes/matchmaking.rs
@@ -1,0 +1,23 @@
+use axum::{
+    routing::{get, post},
+    Router,
+};
+
+use crate::handlers::crud_handlers::{
+    add_friend_handler, change_flag_handler, create_matched_handler, get_accepted_boys_handler,
+    get_boys_handler, get_girl_request_handler, get_girls_handler, get_matched_handler,
+    reject_handler,
+};
+
+pub fn matchmaking_routes() -> Router {
+    Router::new()
+        .route("/getboys", get(get_boys_handler))
+        .route("/getacceptedboys", post(get_accepted_boys_handler))
+        .route("/getgirls", get(get_girls_handler))
+        .route("/getgirlrequests", post(get_girl_request_handler))
+        .route("/addfriend", post(add_friend_handler))
+        .route("/changeflag", post(change_flag_handler))
+        .route("/creatematch", post(create_matched_handler))
+        .route("/getmatched", post(get_matched_handler))
+        .route("/reject", post(reject_handler))
+}

--- a/src/routes/mod.rs
+++ b/src/routes/mod.rs
@@ -1,0 +1,5 @@
+mod auth;
+mod user;
+
+pub use auth::*;
+pub use user::*;

--- a/src/routes/mod.rs
+++ b/src/routes/mod.rs
@@ -1,5 +1,11 @@
 mod auth;
+mod diagnostics;
+mod matchmaking;
+mod score;
 mod user;
 
 pub use auth::*;
+pub use diagnostics::*;
+pub use matchmaking::*;
+pub use score::*;
 pub use user::*;

--- a/src/routes/score.rs
+++ b/src/routes/score.rs
@@ -1,0 +1,9 @@
+use axum::{routing::put, Router};
+
+use crate::handlers::crud_handlers::{update_contest_score_handler, update_score_handler};
+
+pub fn score_routes() -> Router {
+    Router::new()
+        .route("/updatescore", put(update_score_handler))
+        .route("/updatecontestscore", put(update_contest_score_handler))
+}

--- a/src/routes/user.rs
+++ b/src/routes/user.rs
@@ -1,0 +1,7 @@
+use axum::{routing::get, Router};
+
+use crate::handlers::crud_handlers::get_all_users_handler;
+
+pub fn user_routes() -> Router {
+    Router::new().route("/getallusers", get(get_all_users_handler))
+}

--- a/src/routes/user.rs
+++ b/src/routes/user.rs
@@ -1,7 +1,16 @@
-use axum::{routing::get, Router};
+use axum::{
+    routing::{get, post, put},
+    Router,
+};
 
-use crate::handlers::crud_handlers::get_all_users_handler;
+use crate::handlers::crud_handlers::{
+    get_all_users_handler, get_user_by_id_handler, get_user_handler, update_user_character_handler,
+};
 
 pub fn user_routes() -> Router {
-    Router::new().route("/getallusers", get(get_all_users_handler))
+    Router::new()
+        .route("/getuser", post(get_user_handler))
+        .route("/getallusers", get(get_all_users_handler))
+        .route("/updatecharacter", put(update_user_character_handler))
+        .route("/getuserbyid", post(get_user_by_id_handler))
 }


### PR DESCRIPTION
## Problem
As the number of routes in `lib.rs` grows, it's essential to keep the file organized.

## Solution
Split routes into separate modules

## Notes
More details - [issue](https://github.com/Sidharth-Singh10/Affinity-backend/issues/1)

## Workflow
- [x] Initial commit
- [ ] Agree on route groups and solution
- [ ] Finish migration for the rest of the routes